### PR TITLE
Epic/#2 letsjo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,7 +23,8 @@ module.exports = {
     'no-console': ['warn', { allow: ['error'] }],
     eqeqeq: 'error',
     'dot-notation': 'error',
-    'no-unused-vars': 'error',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'import/order': [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,15 @@
+import { Suspense } from 'react';
+import { RouterProvider } from 'react-router';
+import { router } from 'src/router';
+
+import Loading from './pages/Loading';
+
 function App() {
-  return <div className='App'>App</div>;
+  return (
+    <Suspense fallback={<Loading />}>
+      <RouterProvider router={router} />
+    </Suspense>
+  );
 }
 
 export default App;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,18 @@
+import { PATH_API } from '../constants/path';
+
+const request = async (url: string) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    alert('에러가 발생했습니다.');
+    console.error(response);
+  }
+  return response.json();
+};
+
+const DataApi = {
+  async getData() {
+    return await request(PATH_API.data);
+  },
+};
+
+export default DataApi;

--- a/src/components/Detail/index.tsx
+++ b/src/components/Detail/index.tsx
@@ -1,0 +1,85 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+  Button,
+  Box,
+  Image,
+  Flex,
+  Heading,
+  Tag,
+  ButtonGroup,
+} from '@chakra-ui/react';
+
+import InputNumberWithButton from '../public/InputNumberWithButton';
+
+const Detail = ({
+  count,
+  isOpen,
+  onClose,
+  product,
+  handleQuantity,
+}: {
+  count: number;
+  isOpen: boolean;
+  product?: Product;
+  onClose: () => void;
+  handleQuantity: (value: number) => void;
+}) => {
+  return (
+    <Modal blockScrollOnMount={false} size='3xl' isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>상품 정보</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Flex width='100%' direction={{ base: 'column', sm: 'row' }} overflow='hidden'>
+            <Image
+              objectFit='cover'
+              maxW={{ base: '100%', sm: '500px' }}
+              src={product?.mainImage}
+              alt={product?.name}
+              borderRadius='lg'
+            />
+            <Flex width='100%' direction={{ base: 'column' }} justifyContent='space-between' pl='5'>
+              <Box>
+                <Heading display='flex' alignItems='center' size='md'>
+                  <Tag mr='2' size='lg' variant='solid' colorScheme='teal'>
+                    {product?.spaceCategory}
+                  </Tag>
+                  {product?.name}
+                </Heading>
+                <Text py='2'>{product?.description}</Text>
+              </Box>
+              <Box>
+                <Flex justifyContent='flex-end'>
+                  <Text fontWeight='500' color='blue.600' fontSize='2xl'>
+                    {'￦' + product?.price.toLocaleString('ko-KR')}
+                  </Text>
+                </Flex>
+                <Text pt='2px' textAlign='right'>
+                  {'잔여수: ' + product?.maximumPurchases + '개'}
+                </Text>
+              </Box>
+            </Flex>
+          </Flex>
+        </ModalBody>
+        <ModalFooter>
+          <ButtonGroup spacing='2'>
+            <InputNumberWithButton count={count} handleQuantity={handleQuantity} />
+            <Button variant='solid' colorScheme='blue'>
+              담기
+            </Button>
+          </ButtonGroup>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default Detail;

--- a/src/components/ProductsList/Filter/index.tsx
+++ b/src/components/ProductsList/Filter/index.tsx
@@ -1,0 +1,57 @@
+import { ChevronRightIcon } from '@chakra-ui/icons';
+import { ChevronLeftIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Checkbox,
+  Flex,
+  RangeSlider,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+  RangeSliderTrack,
+  Text,
+} from '@chakra-ui/react';
+
+const Filter = () => {
+  return (
+    <Box mt='50px' mb='20px' pl='15px' height='150px'>
+      <Flex height='60%' borderBottom='1px' borderBottomColor='#868686'>
+        <Text margin='0px 30px' display='flex' alignItems='center' fontSize='xl'>
+          가격
+        </Text>
+        <RangeSlider width='400px' height='50%' aria-label={['min', 'max']} defaultValue={[10, 30]}>
+          <RangeSliderTrack>
+            <RangeSliderFilledTrack />
+          </RangeSliderTrack>
+          <RangeSliderThumb boxSize={5} index={0}>
+            <Box color='#222' as={ChevronLeftIcon} />
+          </RangeSliderThumb>
+          <RangeSliderThumb boxSize={5} index={1}>
+            <Box color='#222' as={ChevronRightIcon} />
+          </RangeSliderThumb>
+        </RangeSlider>
+      </Flex>
+      <Flex height='40%' borderBottom='1px' borderBottomColor='#868686'>
+        <Text margin='0px 30px' display='flex' alignItems='center' fontSize='xl'>
+          지역
+        </Text>
+        <Checkbox mr='20px' size='lg' colorScheme='orange' defaultChecked>
+          서울
+        </Checkbox>
+        <Checkbox mr='20px' size='lg' colorScheme='orange' defaultChecked>
+          서울
+        </Checkbox>
+        <Checkbox mr='20px' size='lg' colorScheme='orange' defaultChecked>
+          서울
+        </Checkbox>
+        <Checkbox mr='20px' size='lg' colorScheme='orange' defaultChecked>
+          서울
+        </Checkbox>
+        <Checkbox mr='20px' size='lg' colorScheme='orange' defaultChecked>
+          서울
+        </Checkbox>
+      </Flex>
+    </Box>
+  );
+};
+
+export default Filter;

--- a/src/components/ProductsList/PhotoCard/index.tsx
+++ b/src/components/ProductsList/PhotoCard/index.tsx
@@ -1,0 +1,99 @@
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  Heading,
+  Button,
+  Divider,
+  Text,
+  Image,
+  Tag,
+  Flex,
+  Spacer,
+  Box,
+  ButtonGroup,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useState } from 'react';
+
+import Detail from '@/components/Detail';
+import InputNumberWithButton from '@/components/public/InputNumberWithButton';
+
+interface PhotoCardProps {
+  product: Product;
+  name: string;
+  mainImage: string;
+  description: string;
+  price: number;
+  spaceCategory: string;
+}
+
+const PhotoCard = ({
+  product,
+  name,
+  mainImage,
+  description,
+  price,
+  spaceCategory,
+}: PhotoCardProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const [count, setCount] = useState(1);
+
+  const handleQuantity = (value: number) => {
+    setCount(value);
+  };
+
+  return (
+    <Card>
+      <Detail
+        count={count}
+        isOpen={isOpen}
+        product={product}
+        onClose={onClose}
+        handleQuantity={handleQuantity}
+      />
+      <CardBody onClick={onOpen}>
+        <Image
+          src={mainImage}
+          alt={name}
+          objectFit='cover'
+          width={{ base: '100%' }}
+          borderRadius='lg'
+        />
+        <Box
+          display='flex'
+          pt='10px'
+          height='130px'
+          flexDirection='column'
+          alignItems='space-between'
+        >
+          <Heading size='md'>
+            <Tag variant='solid' colorScheme='teal' mt='-0.5' mr='2' mb='1' size='lg'>
+              {spaceCategory}
+            </Tag>
+            {name}
+          </Heading>
+          <Text>{description}</Text>
+          <Spacer />
+        </Box>
+        <Flex justifyContent='space-between'>
+          <Text color='blue.600' fontSize='2xl'>
+            {'￦' + price.toLocaleString('ko-KR')}
+          </Text>
+        </Flex>
+      </CardBody>
+      <Divider />
+      <CardFooter>
+        <ButtonGroup spacing='2'>
+          <InputNumberWithButton count={count} handleQuantity={handleQuantity} />
+          <Button width='50%' variant='solid' colorScheme='blue'>
+            담기
+          </Button>
+        </ButtonGroup>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default PhotoCard;

--- a/src/components/ProductsList/index.tsx
+++ b/src/components/ProductsList/index.tsx
@@ -1,0 +1,42 @@
+import { Box, SimpleGrid } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+import DataApi from '@/apis';
+
+import Filter from './Filter';
+import PhotoCard from './PhotoCard';
+
+const ProductsList = () => {
+  const [products, setProducts] = useState<null | Product[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await DataApi.getData();
+      setProducts(response);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <Box w='100%' maxWidth='1300px'>
+      <Filter />
+      <SimpleGrid minChildWidth='250px' gap='30px'>
+        {products &&
+          products.map((product) => (
+            <PhotoCard
+              key={product.idx}
+              product={product}
+              name={product.name}
+              mainImage={product.mainImage}
+              description={product.description}
+              price={product.price}
+              spaceCategory={product.spaceCategory}
+            />
+          ))}
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export default ProductsList;

--- a/src/components/public/InputNumberWithButton/index.tsx
+++ b/src/components/public/InputNumberWithButton/index.tsx
@@ -1,9 +1,15 @@
 import { Button, HStack, Input, useNumberInput } from '@chakra-ui/react';
 
-const InputNumberWithButton = ({ handleQuantity }: { handleQuantity: (value: number) => void }) => {
+const InputNumberWithButton = ({
+  count,
+  handleQuantity,
+}: {
+  count: number;
+  handleQuantity: (value: number) => void;
+}) => {
   const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } = useNumberInput({
     step: 1,
-    defaultValue: 1,
+    defaultValue: count,
     min: 1,
     precision: 0,
   });

--- a/src/components/public/InputNumberWithButton/index.tsx
+++ b/src/components/public/InputNumberWithButton/index.tsx
@@ -1,0 +1,26 @@
+import { Button, HStack, Input, useNumberInput } from '@chakra-ui/react';
+
+const InputNumberWithButton = ({ handleQuantity }: { handleQuantity: (value: number) => void }) => {
+  const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } = useNumberInput({
+    step: 1,
+    defaultValue: 1,
+    min: 1,
+    precision: 0,
+  });
+
+  const inc = getIncrementButtonProps();
+  const dec = getDecrementButtonProps();
+  const input = getInputProps();
+
+  handleQuantity(Number(input.value));
+
+  return (
+    <HStack maxW='230px'>
+      <Button {...inc}>+</Button>
+      <Input textAlign='center' {...input} />
+      <Button {...dec}>-</Button>
+    </HStack>
+  );
+};
+
+export default InputNumberWithButton;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './path';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,10 @@
+export const PATH_ROUTE = Object.freeze({
+  root: '/',
+  main: '/main',
+  reservations: '/reservations',
+  any: '/*',
+});
+
+export const PATH_API = Object.freeze({
+  data: './src/mocks/data.json',
+});

--- a/src/pages/Error/index.tsx
+++ b/src/pages/Error/index.tsx
@@ -1,0 +1,15 @@
+import { useNavigate } from 'react-router';
+import { PATH_ROUTE } from 'src/constants';
+
+const Error = () => {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <h5>404 페이지</h5>
+      <button onClick={() => navigate(PATH_ROUTE.main)}>메인 페이지로 가기</button>
+      <button onClick={() => navigate(-1)}>이전 페이지로 돌아가기</button>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,0 +1,13 @@
+import { Box } from '@chakra-ui/react';
+
+import ProductsList from '@/components/ProductsList';
+
+const Home = () => {
+  return (
+    <Box display='flex' width='100vw' justifyContent='center'>
+      <ProductsList />
+    </Box>
+  );
+};
+
+export default Home;

--- a/src/pages/Layout/Header/index.tsx
+++ b/src/pages/Layout/Header/index.tsx
@@ -1,0 +1,31 @@
+import { ButtonGroup, Button, Flex, Spacer, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+
+import { PATH_ROUTE } from '@/constants/path';
+
+const Header = () => {
+  const navigate = useNavigate();
+
+  const handleClick = (pathDirection: string) => {
+    navigate(pathDirection);
+  };
+
+  return (
+    <Flex maxWidth='1300px' width='100vw' alignItems='center' gap='2' p='2'>
+      <Button variant='ghost' onClick={() => handleClick(PATH_ROUTE.main)}>
+        <Heading size='lg'>Wanted Pre-onboarding Team5</Heading>
+      </Button>
+      <Spacer />
+      <ButtonGroup gap='2' pt='1' pr='2'>
+        <Button colorScheme='blue' onClick={() => handleClick(PATH_ROUTE.main)}>
+          HOME
+        </Button>
+        <Button colorScheme='blue' onClick={() => handleClick(PATH_ROUTE.reservations)}>
+          장바구니
+        </Button>
+      </ButtonGroup>
+    </Flex>
+  );
+};
+
+export default Header;

--- a/src/pages/Layout/index.tsx
+++ b/src/pages/Layout/index.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@chakra-ui/react';
+import { Outlet } from 'react-router-dom';
+
+import Header from './Header';
+
+const Layout = () => {
+  return (
+    <Box display='flex' flexDirection='column' alignItems='center'>
+      <Header />
+      <Outlet />
+    </Box>
+  );
+};
+
+export default Layout;

--- a/src/pages/Loading/index.tsx
+++ b/src/pages/Loading/index.tsx
@@ -1,0 +1,11 @@
+import { Flex, Spinner } from '@chakra-ui/react';
+
+const Loading = () => {
+  return (
+    <Flex>
+      <Spinner thickness='4px' speed='0.65s' emptyColor='gray.200' color='blue.500' size='xl' />
+    </Flex>
+  );
+};
+
+export default Loading;

--- a/src/pages/Reservations/index.tsx
+++ b/src/pages/Reservations/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Reservations = () => {
+  return <div>Reservations</div>;
+};
+
+export default Reservations;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,0 +1,39 @@
+import { lazy } from 'react';
+import { createBrowserRouter } from 'react-router-dom';
+import { PATH_ROUTE } from 'src/constants';
+
+import { rootLoader } from './loaders';
+
+const Error = lazy(() => import('@/pages/Error'));
+const Home = lazy(() => import('@/pages/Home'));
+const Layout = lazy(() => import('@/pages/Layout'));
+const Reservations = lazy(() => import('@/pages/Reservations'));
+
+const routes = [
+  {
+    path: PATH_ROUTE.root,
+    element: <Layout />,
+    errorElement: <Error />,
+    children: [
+      {
+        path: PATH_ROUTE.root,
+        element: <Home />,
+        loader: rootLoader,
+      },
+      {
+        path: PATH_ROUTE.main,
+        element: <Home />,
+      },
+      {
+        path: PATH_ROUTE.reservations,
+        element: <Reservations />,
+      },
+      {
+        path: PATH_ROUTE.any,
+        element: <Error />,
+      },
+    ],
+  },
+];
+
+export const router = createBrowserRouter(routes);

--- a/src/router/loaders/index.ts
+++ b/src/router/loaders/index.ts
@@ -1,0 +1,1 @@
+export * from './rootLoader';

--- a/src/router/loaders/rootLoader.ts
+++ b/src/router/loaders/rootLoader.ts
@@ -1,0 +1,7 @@
+import { redirect } from 'react-router-dom';
+
+import { PATH_ROUTE } from '@/constants';
+
+export const rootLoader = () => {
+  return redirect(PATH_ROUTE.main);
+};

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,14 @@
+export {};
+
+declare global {
+  interface Product {
+    idx: number;
+    name: string;
+    description: string;
+    mainImage: string;
+    price: number;
+    registrationDate: string;
+    maximumPurchases: number;
+    spaceCategory: string;
+  }
+}


### PR DESCRIPTION
## Description

- **[메인 페이지 구현 #2](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/2)**(`/main`)

    - [x]  [요구사항 1. mock_data.json을 활용하여 상품 리스트를 나열한다. #4](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/4)
        -  api 확장성을 생각해서 `fetch` api 를 따로 만들어, 모듈화 하였습니다.
        - 받아온 데이터를 `ProductList` 에서 값을 state에 저장하고 아래 자식 component로 전달해주었습니다.
        - `ProductList` 에서 Filter 를 담당하는 component와 list 를 담당하는 component가 나뉘게되어 두 곳 다 데이터가 필요하기 때문에 `ProductList` 단에서 데이터를 받아왔습니다.
        - 수량을 선택하여 담을 수 있도록 구현하기 위해, `InputNumberWithButton` 컴포넌트를 만들어 재사용성을 높혔습니다.

    - [x]  [요구사항 2. 리스트 아이템 클릭시 모달창을 띄운다. #5](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/5)
        - 상품 카드 내부 상단 요소에 `onClick` 이벤트에 클릭핸들러 함수를 달아 모듈창이 열릴 수 있도록 구현했습니다.
        - 차후 리펙토링 때, 모달창과 상품상세설명서를 따로 떨어뜨려서 모달창의 재활용성을 높힐 수 있을 것 같습니다.
        - 위 요구사항 1에서 상품 리스트를 나열 할 때, 상품카드에 해당 product data를 미리 심어놓고, 클릭시에 따로 Data 요청할 필요가 없게 구현했습니다. 

    - [ ]  [요구사항 3. 리스트 아이템의 모달창의 예약 버튼을 클릭하면 장바구니에 저장된다. (CREATE) #6](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/6)

    - [ ]  [요구사항 4. 아이템 필터 기능을 구현한다. #7](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/7)

    - [x]  [요구사항 5. `/` 경로로 진입 시 `/main`으로 리다이렉트한다. #8](https://github.com/wanted-pre-onboarding-team5/pre-onboarding-9th-2-5/issues/8)
        - router의 `loader` 기능을 활용해서 주소창이 root 경로 일 경우 `/main` path 로 이동하게 만들었습니다.
        - 추가적으로, 개발자가 의도하지 않은 페이지에 진입 할 경우 `Error` 페이지를 띄울 수 있도록 처리했습니다.

## Visuals

- 요구사항 1번 [#4] 
- 요구사항 2번 [#5]
![요구사항1,2](https://user-images.githubusercontent.com/98210863/223874315-34a1c79e-3f8e-44c0-a233-43bfe5ce82be.gif)

- 요구사항 5번 [#8] 
![요구사항5](https://user-images.githubusercontent.com/98210863/223874342-3b393a7e-b1f1-4445-ae8a-aa977755b865.gif)
