### PR TITLE
Epic/#3 eunwoo

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,17 +1,5 @@
-import {
-  Card,
-  CardBody,
-  Image,
-  Stack,
-  Text,
-  Heading,
-  Flex,
-  Button,
-  useToast,
-} from '@chakra-ui/react';
+import { Card, CardBody, Image, Stack, Text, Heading, Flex } from '@chakra-ui/react';
 import { useState } from 'react';
-
-import { RESERVE_LIST_KEY } from '@/constants';
 
 import { ProductModal } from './ProductModal';
 
@@ -19,29 +7,9 @@ export const ProductCard = (props: Product) => {
   const { idx, name, mainImage, description, price, spaceCategory } = props;
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const toast = useToast();
 
   const handleModal = () => {
     setIsOpen((prevIsOpen) => !prevIsOpen);
-  };
-
-  const handleReserve = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    const reserveList = localStorage.getItem(RESERVE_LIST_KEY)?.split(' ') || [];
-    if (reserveList.includes(idx + '')) {
-      toast({
-        title: '이미 예약하신 상품입니다.',
-        status: 'error',
-        duration: 2000,
-      });
-      return;
-    }
-    toast({
-      title: '예약이 완료되었습니다.',
-      status: 'info',
-      duration: 2000,
-    });
-    localStorage.setItem(RESERVE_LIST_KEY, `${reserveList.join(' ')} ${idx}`);
   };
 
   return (
@@ -65,9 +33,6 @@ export const ProductCard = (props: Product) => {
                 {spaceCategory}
               </Text>
             </Flex>
-            <Button colorScheme='blue' onClick={handleReserve}>
-              예약
-            </Button>
           </Stack>
         </CardBody>
       </Card>

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -11,7 +11,11 @@ import {
   Text,
   Heading,
   Flex,
+  Button,
+  useToast,
 } from '@chakra-ui/react';
+
+import { RESERVE_LIST_KEY } from '@/constants';
 
 interface ProductModalProps {
   isOpen: boolean;
@@ -30,6 +34,28 @@ export const ProductModal = ({ isOpen, onClose, product }: ProductModalProps) =>
     maximumPurchases,
     registrationDate,
   } = product;
+
+  const toast = useToast();
+
+  const handleReserve = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const reserveList = localStorage.getItem(RESERVE_LIST_KEY)?.split(' ') || [];
+    if (reserveList.includes(idx + '')) {
+      toast({
+        title: '이미 예약하신 상품입니다.',
+        status: 'error',
+        duration: 2000,
+      });
+      return;
+    }
+    toast({
+      title: '예약이 완료되었습니다.',
+      status: 'info',
+      duration: 2000,
+    });
+    localStorage.setItem(RESERVE_LIST_KEY, `${reserveList.join(' ')} ${idx}`);
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='2xl'>
       <ModalOverlay />
@@ -40,7 +66,7 @@ export const ProductModal = ({ isOpen, onClose, product }: ProductModalProps) =>
           <Image src={mainImage} alt='' borderRadius='lg' h='300' />
           <Stack w='full' justifyContent='space-between'>
             <Heading fontSize='18px'>{name}</Heading>
-            <Text h='140'>{description}</Text>
+            <Text h='142'>{description}</Text>
             <Text color='gray.600' alignSelf='end' fontWeight='bold' fontSize='lg'>
               {spaceCategory}
             </Text>
@@ -49,9 +75,12 @@ export const ProductModal = ({ isOpen, onClose, product }: ProductModalProps) =>
                 {`₩${price.toLocaleString()}`}
               </Text>
               <Text color='gray.600' fontSize='lg'>
-                {`잔여 : ${maximumPurchases}개`}
+                {`최대 구매 수량 : ${maximumPurchases}개`}
               </Text>
             </Flex>
+            <Button colorScheme='blue' onClick={handleReserve}>
+              예약
+            </Button>
             <Text color='gray.500' fontSize='sm' alignSelf='end'>
               {registrationDate.slice(0, registrationDate.length - 3)}
             </Text>

--- a/src/components/ReservedProduct.tsx
+++ b/src/components/ReservedProduct.tsx
@@ -1,0 +1,55 @@
+import { AddIcon, DeleteIcon, MinusIcon } from '@chakra-ui/icons';
+import { Tr, Td, Button } from '@chakra-ui/react';
+
+interface ReservedProductProps extends Product {
+  cnt: number;
+  handleCountPlus: (idx: number) => void;
+  handleCountMinus: (idx: number) => void;
+  handleDelete: (idx: number) => void;
+}
+
+export const ReservedProduct = ({
+  idx,
+  name,
+  spaceCategory,
+  price,
+  cnt,
+  maximumPurchases,
+  handleCountPlus,
+  handleCountMinus,
+  handleDelete,
+}: ReservedProductProps) => {
+  return (
+    <Tr>
+      <Td fontWeight='semibold'>{name}</Td>
+      <Td fontWeight='semibold'>{spaceCategory}</Td>
+      <Td fontWeight='semibold' textAlign='center'>
+        <Button
+          isDisabled={cnt <= 1}
+          borderRadius='full'
+          mr='3'
+          onClick={() => handleCountMinus(idx)}
+        >
+          <MinusIcon />
+        </Button>
+        {cnt}
+        <Button
+          isDisabled={cnt >= maximumPurchases}
+          borderRadius='full'
+          ml='3'
+          onClick={() => handleCountPlus(idx)}
+        >
+          <AddIcon />
+        </Button>
+      </Td>
+      <Td fontWeight='semibold' textAlign='center'>
+        {(price * cnt).toLocaleString()}
+      </Td>
+      <Td>
+        <Button onClick={() => handleDelete(idx)}>
+          <DeleteIcon />
+        </Button>
+      </Td>
+    </Tr>
+  );
+};

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,103 @@
+import { Table, Thead, Tbody, Tfoot, Tr, Th, TableContainer, Heading, Td } from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+
+import { RESERVE_LIST_KEY } from '@/constants';
+
+import { ReservedProduct } from '@/components/ReservedProduct';
+
+export const CartPage = () => {
+  const [reservedProducts, setReservedProducts] = useState<(Product & { cnt: number })[]>([]);
+
+  useEffect(() => {
+    const reserveIdxs = localStorage.getItem(RESERVE_LIST_KEY)?.trim().split(' ');
+    const fetchData = async () => {
+      const response = await fetch('src/mocks/data.json').then((response) => response.json());
+      setReservedProducts(
+        response
+          .filter((product: Product) => reserveIdxs?.includes(product.idx + ''))
+          .map((product: Product) => ({ ...product, cnt: 1 })),
+      );
+    };
+
+    fetchData();
+  }, []);
+
+  const handleCountPlus = (idx: number) => {
+    setReservedProducts(
+      reservedProducts.map((item) => (item.idx === idx ? { ...item, cnt: item.cnt + 1 } : item)),
+    );
+  };
+
+  const handleCountMinus = (idx: number) => {
+    setReservedProducts(
+      reservedProducts.map((item) => (item.idx === idx ? { ...item, cnt: item.cnt - 1 } : item)),
+    );
+  };
+
+  const handleDelete = (idx: number) => {
+    const reserveIdxs = localStorage.getItem(RESERVE_LIST_KEY)?.trim().split(' ');
+    localStorage.setItem(
+      RESERVE_LIST_KEY,
+      reserveIdxs?.filter((key) => +key !== idx).join(' ') || '',
+    );
+    setReservedProducts(reservedProducts.filter((product) => product.idx !== idx));
+  };
+
+  const totalPrice = (reservedProducts: (Product & { cnt: number })[]) => {
+    return reservedProducts.reduce((acc, cur) => acc + cur.price * cur.cnt, 0);
+  };
+
+  return (
+    <>
+      <Heading mt='50px' ml='20px'>
+        장바구니
+      </Heading>
+      <TableContainer mt='20px' border='1px' borderRadius='xl' borderColor='gray.200'>
+        <Table variant='simple'>
+          <Thead>
+            <Tr>
+              <Th fontSize='md'>상품</Th>
+              <Th fontSize='md'>지역</Th>
+              <Th fontSize='md' textAlign='center'>
+                수량
+              </Th>
+              <Th fontSize='md' w='140px' textAlign='center'>
+                금액
+              </Th>
+              <Th w='1'></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {reservedProducts ? (
+              reservedProducts?.map((reservedProduct: Product & { cnt: number }) => (
+                <ReservedProduct
+                  key={reservedProduct.idx}
+                  {...reservedProduct}
+                  handleCountPlus={handleCountPlus}
+                  handleCountMinus={handleCountMinus}
+                  handleDelete={handleDelete}
+                />
+              ))
+            ) : (
+              <Tr>
+                <Td textColor='gray.400' textAlign='center' colSpan={5}>
+                  장바구니가 비어있습니다.
+                </Td>
+              </Tr>
+            )}
+          </Tbody>
+          <Tfoot>
+            <Tr>
+              <Th isNumeric colSpan={3} fontSize='md'>
+                합계
+              </Th>
+              <Th fontSize='md' textAlign='center'>
+                {totalPrice(reservedProducts).toLocaleString()}
+              </Th>
+            </Tr>
+          </Tfoot>
+        </Table>
+      </TableContainer>
+    </>
+  );
+};

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export * from './Main';
 export * from './Root';
+export * from './Cart';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter, RouteObject } from 'react-router-dom';
 
-import { RootPage, MainPage } from '@/pages';
+import { RootPage, MainPage, CartPage } from '@/pages';
 
 import { Layout } from '@/layouts/Layout';
 
@@ -12,7 +12,12 @@ const routes: RouteObject[] = [
   {
     path: '/main',
     element: <Layout />,
-    children: [{ path: '', element: <MainPage /> }],
+    children: [{ index: true, element: <MainPage /> }],
+  },
+  {
+    path: '/reservations',
+    element: <Layout />,
+    children: [{ index: true, element: <CartPage /> }],
   },
 ];
 


### PR DESCRIPTION
## Description

> 1.  **#9 진행사항**

- 데이터 요청 내부에서 로컬 스토리지에 저장한 idx 값으로 장바구니에 담긴 결과값을 걸러내 상태로 관리하였습니다.
- 수량에 대한 데이터를 위해 cnt 프로퍼티를 추가하여 상태가 수량을 포함하도록 하였습니다.
- 테이블 컴포넌트를 활용하여 그려지도록 하였습니다.
- idx값만을 스토리지에 저장시켜서 데이터를 다시 받아와야 처리가 가능한데 예약할 때 객체 전체를 저장하고, 스토리지에 저장된 객체를 parse 하여 사용하면 fetch요청은 제거될 수 있을 것 같습니다.

> 2.  **#10 진행사항**

- 수량을 변경하는 함수를 아이템 컴포넌트에 props로 전달하도록 구현하였습니다.
- 최소 1개, 최대 구매 가능 수량을 벗어난 범위는 버튼을 disabled 처리하도록 구현하였습니다.
- 수량에 따라 금액이 표기되도록 구현하였습니다.

> 3.  **#11 진행사항**

- 삭제되어야 하는 idx를 인수로 전달받는 핸들러를 아이템 컴포넌트에 전달하여 삭제처리 가능하도록 구현하였습니다.
- 로컬 스토리지에 저장된 idx 값들 중 삭제된 데이터의 idx값을 제거하도록 구현하였습니다.

> 4.  **#12 진행사항**

- reduce 메서드를 사용하여 상태의 수량과 금액을 곱한 전체 총금액을 계산하여 그려지도록 구현하였습니다.

이 외 예약 버튼의 위치를 모달 내부로 옮기는 작업을 실시하였습니다.

오후 일정에 문제가 생겨 급하게 구현하다보니 부족한 부분이 많은 것 같습니다😢

## Visuals

![ezgif-4-4f4717d243](https://user-images.githubusercontent.com/95074093/224008998-d4f1bee6-1ce0-40a6-bcf7-b2149b62bf78.gif)

